### PR TITLE
リリースCIを修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
     steps:
       - name: Download build artifact
         uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
 
       - name: Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
- releaseジョブがbuildジョブのあとに実行されるように修正
- PRのclosedイベントでもジョブが発火するように修正
- merge-multipleをtrueに変更
