### PR TITLE
short optionの引数を解析するときにparse関数がエラーを返す不具合を修正

### DIFF
--- a/parsearg.cpp
+++ b/parsearg.cpp
@@ -159,6 +159,7 @@ parsearg_error_t parser::parse_char_option(int& i, const std::vector<std::string
         }
         if (j + 1 < arg_list[i].length()) {
             parsed_options[found_option.name] = arg_list[i].substr(j + 1);
+            return PARSE_OK;
         } else if (i + 1 < arg_list.size()) {
             parsed_options[found_option.name] = arg_list[i++ + 1];
             return PARSE_OK;

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -13,7 +13,8 @@ TEST(parsearg_test, argument_test) {
     char *argv[] = {"program_name", "arg1", "arg2"};
     pa.argument("foo", "foo is mock");
     pa.argument("bar", "bar is mock");
-    pa.parse(argc, argv);
+    auto err = pa.parse(argc, argv);
+    EXPECT_EQ(err, parsearg::PARSE_OK);
     EXPECT_EQ(pa.parsed_value("foo", false), "arg1");
     EXPECT_EQ(pa.parsed_value("bar", false), "arg2");
 }
@@ -25,7 +26,8 @@ TEST(parsearg_test, option_test) {
     char *argv[] = {"program_name", "--opt2"};
     pa.option("opt1", "opt1 is mock", false);
     pa.option("opt2", "opt2 is mock", false);
-    pa.parse(argc, argv);
+    auto err = pa.parse(argc, argv);
+    EXPECT_EQ(err, parsearg::PARSE_OK);
     EXPECT_FALSE(pa.contains_option("opt1"));
     EXPECT_TRUE(pa.contains_option("opt2"));
 }
@@ -37,7 +39,8 @@ TEST(parsearg_test, option_with_argument_test) {
     char *argv[] = {"program_name", "--opt1", "arg1", "--opt2", "arg2"};
     pa.option("opt1", "opt1 is mock", true);
     pa.option("opt2", "opt2 is mock", true);
-    pa.parse(argc, argv);
+    auto err = pa.parse(argc, argv);
+    EXPECT_EQ(err, parsearg::PARSE_OK);
     EXPECT_TRUE(pa.contains_option("opt1"));
     EXPECT_TRUE(pa.contains_option("opt2"));
     EXPECT_EQ(pa.parsed_value("opt1", true), "arg1");
@@ -54,7 +57,8 @@ TEST(parsearg_test, option_shortname_test) {
     pa.option("optC", "optC is mock", false, 'C');
     pa.option("optD", "optD is mock", true, 'D');
     pa.option("optE", "optE is mock", true, 'E');
-    pa.parse(argc, argv);
+    auto err = pa.parse(argc, argv);
+    EXPECT_EQ(err, parsearg::PARSE_OK);
     EXPECT_TRUE(pa.contains_option("optA"));
     EXPECT_TRUE(pa.contains_option("optB"));
     EXPECT_TRUE(pa.contains_option("optC"));


### PR DESCRIPTION
- parse関数の戻り値のテストコードを追加
- short optionの引数解析時にエラーが発生する不具合を修正
